### PR TITLE
fix: Update Dependencies.swift to resolve project generation error

### DIFF
--- a/Tuist/Dependencies.swift
+++ b/Tuist/Dependencies.swift
@@ -1,8 +1,8 @@
 import ProjectDescription
 
 let dependencies = Dependencies(
-    swiftPackageManager: [
-        .remote(url: "https://github.com/JonasGessner/JGProgressHUD", requirement: .upToNextMajor(from: "2.0.0")),
+    carthage: [
+        .github(path: "JonasGessner/JGProgressHUD", requirement: .upToNext("2.0.0")),
     ],
     platforms: [.iOS]
 )


### PR DESCRIPTION
The SPM dependency of  `JGProgressHUD` will cause Tuist generation error, so I update it to using Carthage dependency. See https://github.com/ronanociosoig/Tuist-Pokedex/issues/9